### PR TITLE
Ios 7049 icp transaction build

### DIFF
--- a/Sources/IcpKit/Canisters/CandidValue+ICPTypes.swift
+++ b/Sources/IcpKit/Canisters/CandidValue+ICPTypes.swift
@@ -24,8 +24,8 @@ extension CandidValue {
         ])
     }
     
-    static func ICPTimestampNow() -> CandidValue {
-        return ICPTimestamp(UInt64(Date().timeIntervalSince1970) * 1_000_000_000)
+    static func ICPTimestamp(date: Date = Date()) -> CandidValue {
+        return ICPTimestamp(UInt64(date.timeIntervalSince1970) * 1_000_000_000)
     }
 }
 

--- a/Sources/IcpKit/Cryptography/ICPSign.swift
+++ b/Sources/IcpKit/Cryptography/ICPSign.swift
@@ -13,14 +13,17 @@ import CryptoKit
 public struct ICPSigningInput {
     /// Input transaction parameters
     public let transactionParams: ICPTransactionParams
+    private let date: Date
     
     /// Creates instance
     /// - Parameters:
     ///   - destination: hex encoded destination address string
     ///   - amount: amount in ICP multiplied by decimals count (8)
+    ///   - date: current date (Date())
     ///   - memo: memo value
-    public init(destination: Data, amount: UInt64, memo: UInt64? = nil) {
-        transactionParams = ICPTransactionParams(destination: destination, amount: amount, memo: memo)
+    public init(destination: Data, amount: UInt64, date: Date, memo: UInt64? = nil) {
+        self.transactionParams = ICPTransactionParams(destination: destination, amount: amount, memo: memo)
+        self.date = date
     }
     
     /// Generates hashes for signing
@@ -43,10 +46,12 @@ public struct ICPSigningInput {
         
         let callRequestContent = ICPRequestBuilder.makeCallRequestContent(
             method: .transfer(
-                params: transactionParams
+                params: transactionParams,
+                createdAt: date
             ),
             requestType: .call,
             sender: sender,
+            date: date,
             nonce: nonce
         )
         
@@ -57,6 +62,7 @@ public struct ICPSigningInput {
         let readStateRequestContent = ICPRequestBuilder.makeReadStateRequestContent(
             paths: paths,
             sender: sender,
+            date: date,
             nonce: nonce
         )
         

--- a/Sources/IcpKit/Cryptography/ICPSign.swift
+++ b/Sources/IcpKit/Cryptography/ICPSign.swift
@@ -13,17 +13,15 @@ import CryptoKit
 public struct ICPSigningInput {
     /// Input transaction parameters
     public let transactionParams: ICPTransactionParams
-    private let date: Date
     
     /// Creates instance
     /// - Parameters:
     ///   - destination: hex encoded destination address string
     ///   - amount: amount in ICP multiplied by decimals count (8)
-    ///   - date: current date (Date())
+    ///   - date: current timestamp
     ///   - memo: memo value
     public init(destination: Data, amount: UInt64, date: Date, memo: UInt64? = nil) {
-        self.transactionParams = ICPTransactionParams(destination: destination, amount: amount, memo: memo)
-        self.date = date
+        transactionParams = ICPTransactionParams(destination: destination, amount: amount, date: date, memo: memo)
     }
     
     /// Generates hashes for signing
@@ -46,12 +44,11 @@ public struct ICPSigningInput {
         
         let callRequestContent = ICPRequestBuilder.makeCallRequestContent(
             method: .transfer(
-                params: transactionParams,
-                createdAt: date
+                params: transactionParams
             ),
             requestType: .call,
             sender: sender,
-            date: date,
+            date: transactionParams.date,
             nonce: nonce
         )
         
@@ -62,7 +59,7 @@ public struct ICPSigningInput {
         let readStateRequestContent = ICPRequestBuilder.makeReadStateRequestContent(
             paths: paths,
             sender: sender,
-            date: date,
+            date: transactionParams.date,
             nonce: nonce
         )
         

--- a/Sources/IcpKit/ICPRequest/ICPMethod.swift
+++ b/Sources/IcpKit/ICPRequest/ICPMethod.swift
@@ -30,7 +30,7 @@ public extension ICPMethod {
         )
     }
     
-    static func transfer(params: ICPTransactionParams) -> ICPMethod {
+    static func transfer(params: ICPTransactionParams, createdAt date: Date) -> ICPMethod {
         ICPMethod(
             canister: ICPSystemCanisters.ledger,
             methodName: "transfer",
@@ -40,7 +40,7 @@ public extension ICPMethod {
                 "amount": .ICPAmount(params.amount),
                 "fee": .ICPAmount(10000),
                 "memo": .natural64(params.memo ?? 0),
-                "created_at_time": .ICPTimestampNow()
+                "created_at_time": .ICPTimestamp(date: date)
             ])
         )
     }

--- a/Sources/IcpKit/ICPRequest/ICPMethod.swift
+++ b/Sources/IcpKit/ICPRequest/ICPMethod.swift
@@ -30,7 +30,7 @@ public extension ICPMethod {
         )
     }
     
-    static func transfer(params: ICPTransactionParams, createdAt date: Date) -> ICPMethod {
+    static func transfer(params: ICPTransactionParams) -> ICPMethod {
         ICPMethod(
             canister: ICPSystemCanisters.ledger,
             methodName: "transfer",
@@ -40,7 +40,7 @@ public extension ICPMethod {
                 "amount": .ICPAmount(params.amount),
                 "fee": .ICPAmount(10000),
                 "memo": .natural64(params.memo ?? 0),
-                "created_at_time": .ICPTimestamp(date: date)
+                "created_at_time": .ICPTimestamp(date: params.date)
             ])
         )
     }

--- a/Sources/IcpKit/ICPRequest/ICPRequestBuilder.swift
+++ b/Sources/IcpKit/ICPRequest/ICPRequestBuilder.swift
@@ -14,6 +14,7 @@ public struct ICPRequestBuilder {
         method: ICPMethod,
         requestType: ICPRequestType,
         sender: ICPPrincipal = .dummy,
+        date: Date,
         nonce: Data
     ) -> ICPCallRequestContent {
         let serialisedArgs = CandidSerialiser().encode(method.args)
@@ -21,7 +22,7 @@ public struct ICPRequestBuilder {
             requestType: requestType,
             sender: sender.bytes,
             nonce: nonce,
-            ingressExpiry: makeIngressExpiry(),
+            ingressExpiry: makeIngressExpiry(date: date),
             methodName: method.methodName,
             canisterID: method.canister.bytes,
             arg: serialisedArgs
@@ -31,6 +32,7 @@ public struct ICPRequestBuilder {
     public static func makeReadStateRequestContent(
         paths: [ICPStateTreePath],
         sender: ICPPrincipal,
+        date: Date,
         nonce: Data
     ) -> ICPReadStateRequestContent {
         let encodedPaths = paths.map { $0.encodedComponents() }
@@ -38,13 +40,13 @@ public struct ICPRequestBuilder {
             requestType: .readState,
             sender: sender.bytes,
             nonce: nonce,
-            ingressExpiry: makeIngressExpiry(),
+            ingressExpiry: makeIngressExpiry(date: date),
             paths: encodedPaths
         )
     }
     
-    private static func makeIngressExpiry(_ seconds: TimeInterval = defaultIngressExpirySeconds) -> Int {
-        let expiryDate = Date().addingTimeInterval(seconds)
+    private static func makeIngressExpiry(date: Date, _ seconds: TimeInterval = defaultIngressExpirySeconds) -> Int {
+        let expiryDate = date.addingTimeInterval(seconds)
         let nanoSecondsSince1970 = expiryDate.timeIntervalSince1970 * 1e9
         return Int(nanoSecondsSince1970)
     }

--- a/Sources/IcpKit/Models/ICPTransactionParams.swift
+++ b/Sources/IcpKit/Models/ICPTransactionParams.swift
@@ -10,11 +10,13 @@ import Foundation
 public struct ICPTransactionParams {
     let destination: Data
     let amount: UInt64
+    let date: Date
     let memo: UInt64?
     
-    public init(destination: Data, amount: UInt64, memo: UInt64?) {
+    public init(destination: Data, amount: UInt64, date: Date, memo: UInt64?) {
         self.destination = destination
         self.amount = amount
+        self.date = date
         self.memo = memo
     }
 }


### PR DESCRIPTION
Пробрасываем дату снаружи чтобы можно было добиться консистентного поведения в юнит-тестах.